### PR TITLE
Fix CI workflow by installing pytest dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install pytest pytest-cov
     
     - name: Run tests
       run: |
@@ -43,7 +44,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install safety
+        pip install safety pytest pytest-cov
     
     - name: Run vulnerability scan
       run: |


### PR DESCRIPTION
## Summary
- Fixed CI workflow failure by explicitly installing pytest and pytest-cov in the build and vulnerability-scan jobs
- Error was occurring because the workflow was trying to run pytest without having installed it first

## Test plan
- CI workflow should now be able to run the pytest command without errors
- Both jobs will have pytest available in their environments

🤖 Generated with [Claude Code](https://claude.ai/code)